### PR TITLE
Fix a bug when an overlay isn't in the remote list

### DIFF
--- a/layman/api.py
+++ b/layman/api.py
@@ -426,6 +426,7 @@ class LaymanAPI(object):
                 message = 'Overlay "%s" could not be found in the remote lists.\n' \
                         'Please check if it has been renamed and re-add if necessary.' % ovl
                 warnings.append((ovl, message))
+                (diff_type, update_url) = (False, False)
             else:
                 self.output.debug("API.sync(); else: self._get_remote_db().select(ovl)", 5)
 


### PR DESCRIPTION
If the overlay isn't in the remote list, we want to continue to the next overlay, which avoids an UnboundLocalError exception on line 437.
