### PR TITLE
layman/db: Ignore an initially-missing installed file

### DIFF
--- a/layman/db.py
+++ b/layman/db.py
@@ -60,6 +60,7 @@ class DB(DbBase):
                           config,
                           paths=[config['installed'], ],
                           ignore=ignore,
+                          allow_missing=True,
                           )
 
         self.repo_conf = RepoConfManager(self.config, self.overlays)

--- a/layman/dbbase.py
+++ b/layman/dbbase.py
@@ -90,7 +90,7 @@ class DbBase(object):
     ''' Handle a list of overlays.'''
 
     def __init__(self, config, paths=None, ignore = 0,
-        ignore_init_read_errors=False
+        ignore_init_read_errors=False, allow_missing=False
         ):
 
         self.config = config
@@ -111,7 +111,7 @@ class DbBase(object):
             self.read_file(path)
             path_found = True
 
-        if not path_found:
+        if not path_found and not allow_missing:
             self.output.warn("Warning: an installed db file was not found at: %s"
                 % str(self.paths))
 


### PR DESCRIPTION
Avoid:

```
$ emerge -av app-portage/layman
$ echo 'source /var/lib/layman/make.conf' >> /etc/portage/make.conf
$ layman --fetch
$ layman --list-local

 * Warning: an installed db file was not found at: ['/var/lib/layman/installed.xml']
```

when that's the expected behavior before you've added any local
repositories.  Instead, interpret the lack of a local file listing
installed repositories as "no repositories installed" and continue
silently on.
