### PR TITLE
[BORKED] Parallel safety

### DIFF
--- a/layman/db.py
+++ b/layman/db.py
@@ -47,6 +47,7 @@ class DB(DbBase):
         self.config = config
         self.output = config['output']
 
+        self.db_mtime = None
         self.path = config['installed']
         self.output.debug("DB.__init__(): config['installed'] = %s" % self.path, 3)
 
@@ -108,9 +109,17 @@ class DB(DbBase):
         return True
 
 
+    def read_file(self, path):
+        '''Read db replacing current entries, if mtime changed.'''
+        mtime = os.fstat(self.get_file(path).fileno()).st_mtime
+        if self.db_mtime != mtime:
+            self.db_mtime = mtime
+            self.overlays = {}
+            DbBase.read_file(self, path)
+
+
     def _reload_db(self):
         '''Reload db if necessary.'''
-        self.overlays = {}
         self.read_file(self.path)
 
 

--- a/layman/dbbase.py
+++ b/layman/dbbase.py
@@ -69,7 +69,7 @@ class UnknownOverlayException(Exception):
 #-------------------------------------------------------------------------------
 
 class BrokenOverlayCatalog(ValueError):
-    def __init__(self, origin, expat_error, hint=None):
+    def __init__(self, origin, etree_error, hint=None):
         if hint == None:
             hint = ''
         else:
@@ -77,7 +77,7 @@ class BrokenOverlayCatalog(ValueError):
 
         super(BrokenOverlayCatalog, self).__init__(
             'XML parsing failed for "%(origin)s" (line %(line)d, column %(column)d)%(hint)s' % \
-            {'line':expat_error.lineno, 'column':expat_error.offset + 1, 'origin':origin, 'hint':hint})
+            {'line':etree_error.position[0], 'column':etree_error.position[1] + 1, 'origin':origin, 'hint':hint})
 
 
 #===============================================================================
@@ -155,7 +155,7 @@ class DbBase(object):
         '''
         try:
             document = ET.fromstring(text)
-        except xml.parsers.expat.ExpatError as error:
+        except ET.ParseError as error:
             raise BrokenOverlayCatalog(origin, error, self._broken_catalog_hint())
 
         overlays = document.findall('overlay') + \


### PR DESCRIPTION
So here's a lot of my effort to get this magic abstraction stuff parallel-friendly. Basically it keeps files open for a long time, and introduces locking in a lot of places. Also re-reading and mtime checks for caching.

It still needs work. Long story short, after some time it randomly starts breaking installed.xml. I have no clue why or how. I'd appreciate a second pair of eyes helping out with this.
