### PR TITLE
Removed hardcoded path /usr/bin from backend path.

### DIFF
--- a/layman/overlays/modules/g_sorcery/g_sorcery.py
+++ b/layman/overlays/modules/g_sorcery/g_sorcery.py
@@ -87,8 +87,7 @@ class GSorceryOverlay(OverlaySource):
             [(self.command(),
              'g-sorcery',
              'app-portage/g-sorcery'),
-
-             ('/usr/bin/' + self.backend,
+             (self.backend,
               self.backend,
               'app-portage/' + self.backend),],
 


### PR DESCRIPTION
resolve_command does this for us already. This screws up paths when using Gentoo Prefix with g_sorcery