### PR TITLE
pm_plugins/portage: drop portage._native_kwargs usage (bug 613936)

### DIFF
--- a/pm_plugins/portage/sync/modules/laymansync/subproc.py
+++ b/pm_plugins/portage/sync/modules/laymansync/subproc.py
@@ -72,7 +72,7 @@ class Layman(NewBase):
 
         exitcode = portage.process.spawn_bash("%(command)s" % \
             ({'command': command}),
-            **portage._native_kwargs(self.spawn_kwargs))
+            **self.spawn_kwargs)
         if exitcode != os.EX_OK:
             msg = "!!! layman add error in %(repo)s"\
                 % ({'repo': self.repo.name})
@@ -111,7 +111,7 @@ class Layman(NewBase):
         command = ' '.join(args)
         exitcode = portage.process.spawn_bash("%(command)s" % \
             ({'command': command}),
-            **portage._native_kwargs(self.spawn_kwargs))
+            **self.spawn_kwargs)
 
         if exitcode != os.EX_OK:
             exitcode = self.new()[0]


### PR DESCRIPTION
The portage._native_kwargs function is not available since
portage-2.3.0.

X-Gentoo-Bug: 613936
X-Gentoo-Bug-URL: https://bugs.gentoo.org/613936