### PR TITLE
add support for eprefix in overlays/modules/g_sorcery/g_sorcery.py

### DIFF
--- a/layman/config.py
+++ b/layman/config.py
@@ -90,6 +90,7 @@ class BareConfig(object):
             self.root = root
 
         self._defaults = {
+            'eroot': path([self.root, EPREFIX, '/']),
             'configdir': path([self.root, EPREFIX,'/etc/layman']),
             'config'    : '%(configdir)s/layman.cfg',
             'storage'   : path([self.root, EPREFIX,'/var/lib/layman']),

--- a/layman/overlays/modules/g_sorcery/g_sorcery.py
+++ b/layman/overlays/modules/g_sorcery/g_sorcery.py
@@ -88,7 +88,7 @@ class GSorceryOverlay(OverlaySource):
              'g-sorcery',
              'app-portage/g-sorcery'),
 
-             ('/usr/bin/' + self.backend,
+             (self.config['eroot'] + '/usr/bin/' + self.backend,
               self.backend,
               'app-portage/' + self.backend),],
 


### PR DESCRIPTION
my eprefix is /r/a/p,
(1)when I run
layman -a pypi    (Using gs-pypi with layman ,following the step in README.md https://github.com/jauhien/gs-pypi/)
got errors:
 * Adding overlay...
 * Overlay "pypi" is not official. Continue installing? [y/n]: y
 * Program "/usr/bin/gs-pypi" not found
 * File /usr/bin/gs-pypi seems to be missing! Overlay type "gs-pypi" not supported. Did you emerge app-portage/gs-pypi?
 * Adding repository "pypi" failed! Possible remains of the operation have NOT been removed and may be left at "/r/a/p/var/lib/layman/pypi". Please remove them manually if required.
(2)File /usr/bin/gs-pypi  should be /r/a/p/usr/bin/gs-pypi