### PR TITLE
remove any remote tracking branches that no longer exist remotely

### DIFF
--- a/layman/overlays/modules/git/git.py
+++ b/layman/overlays/modules/git/git.py
@@ -131,7 +131,7 @@ class GitOverlay(OverlaySource):
         cfg_opts = self.config["git_syncopts"]
         target = path([base, self.parent.name])
 
-        args = ['pull']
+        args = ['pull', '-p']
         if self.config['quiet']:
             args.append('-q')
         if len(cfg_opts):


### PR DESCRIPTION
fix the following error:

```sh
error: cannot lock ref 'refs/remotes/origin/dev/rindeal': 'refs/remotes/origin/dev' exists; cannot create 'refs/remotes/origin/dev/rindeal'                                                                         
From https://github.com/rindeal/rindeal-ebuild-repo                                                                                                                                                                 
 ! [new branch]      dev/rindeal -> origin/dev/rindeal  (unable to update local ref)                               
error: some local refs could not be updated; try running                                                          
 'git remote prune origin' to remove any old, conflicting branches 
```